### PR TITLE
refactor: fix react keys where able to

### DIFF
--- a/src/components/CardCarousel.tsx
+++ b/src/components/CardCarousel.tsx
@@ -60,12 +60,8 @@ const CardCarousel = ({ title, type, items = [] }: ICarouselProps) => {
         <div id={styles["card-wrapper"]} ref={carouselRef}>
           <div id={styles["cards"]}>
             {items.length >= 5
-              ? items.map((item, index) => (
-                  <GalleryItem key={index} {...item} />
-                ))
-              : items.map((item, index) => (
-                  <GalleryItem key={index} {...item} />
-                ))}
+              ? items.map((item) => <GalleryItem key={item.link} {...item} />)
+              : items.map((item) => <GalleryItem key={item.link} {...item} />)}
             {Array(5 - items.length)
               .fill(0)
               .map((_, index) => (

--- a/src/components/CarouselMenu.tsx
+++ b/src/components/CarouselMenu.tsx
@@ -60,11 +60,9 @@ const CardCarousel = ({ title, type, items = [] }: ICarouselProps) => {
         <div id={styles["card-wrapper"]} ref={carouselRef}>
           <div id={styles["cards"]}>
             {items.length >= 5
-              ? items.map((item, index) => (
-                  <GalleryItem key={index} {...item} />
-                ))
+              ? items.map((item) => <GalleryItem key={item.link} {...item} />)
               : items.map((item, index) => (
-                  <GalleryItem key={index} {...item} />
+                  <GalleryItem key={item.link} {...item} />
                 ))}
             {Array(5 - items.length)
               .fill(0)

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import Head from "next/head"
 import Header from "./Header"
-import Footer from "./Footer"
+// import Footer from "./Footer"
 
 export default function Layout({ children }) {
   return (
@@ -16,7 +16,7 @@ export default function Layout({ children }) {
       <div>
         <Header />
         {children}
-        <Footer />
+        {/* <Footer /> */}
       </div>
     </>
   )


### PR DESCRIPTION
# Description
- Cleanup React keys where the data that was being mapped over provided a unique value to use as the key
- You want to avoid using the index of the array for performance reasons because when something is added or removed to a list the index changes, causing React to think everything in the list needs to be rerendered. With large lists this can cause a performance issue
- https://reactjs.org/docs/lists-and-keys.html