### PR TITLE
Updated dotenv package

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@turbo/gen": "^1.10.13",
     "concurrently": "^8.2.1",
+    "dotenv": "^16.3.1",
     "dotenv-cli": "^7.3.0",
     "husky": "^8.0.0",
     "lint-staged": "^14.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2786,7 +2786,7 @@ dotenv@16.0.3:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
   integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
 
-dotenv@^16.3.0:
+dotenv@^16.3.0, dotenv@^16.3.1:
   version "16.3.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
   integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==


### PR DESCRIPTION
To be able to run local dev mode after changing to turbo, couldn't be open due to dotenv errors (>_<)